### PR TITLE
Plugable wait function and retry predicate

### DIFF
--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -233,9 +233,11 @@ func (t *Transport) tries(req *http.Request, try uint) (*http.Response, error) {
 		if t.Stats != nil {
 			t.Stats(stats)
 		}
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+
+	if res == nil {
+		return res, err
 	}
 
 	res.Body = &bodyCloser{

--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -232,9 +232,7 @@ Start:
 			}
 			stats.Duration.Header = headerTime.Sub(startTime)
 			stats.Retry.Count = try
-			fmt.Println("Stats:", stats)
 		}
-		fmt.Println("tries", res, err)
 		if t.Stats != nil {
 			t.Stats(stats)
 		}
@@ -248,6 +246,7 @@ Start:
 			t.Stats(stats)
 		}
 		if try < t.MaxTries {
+			try += 1
 			goto Start
 		}
 	}

--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -233,7 +233,9 @@ func (t *Transport) tries(req *http.Request, try uint) (*http.Response, error) {
 		if t.Stats != nil {
 			t.Stats(stats)
 		}
-		return res, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	res.Body = &bodyCloser{

--- a/httpcontrol_test.go
+++ b/httpcontrol_test.go
@@ -196,18 +196,10 @@ func TestSafeRetry(t *testing.T) {
 	server := httptest.NewUnstartedServer(sleepHandler(time.Millisecond))
 	transport := &httpcontrol.Transport{
 		MaxTries: 2,
-		RetryPolicy: &httpcontrol.RetryPolicy{
-			Retriables: []httpcontrol.Retriable{
-				httpcontrol.TemporaryError,
-				httpcontrol.NetworkError,
-				httpcontrol.RetryOnGet,
-			},
-		},
 	}
 	first := false
 	second := false
 	transport.Stats = func(stats *httpcontrol.Stats) {
-		fmt.Println(stats.String())
 		if !first {
 			first = true
 			if stats.Error == nil {

--- a/httpcontrol_test.go
+++ b/httpcontrol_test.go
@@ -196,10 +196,18 @@ func TestSafeRetry(t *testing.T) {
 	server := httptest.NewUnstartedServer(sleepHandler(time.Millisecond))
 	transport := &httpcontrol.Transport{
 		MaxTries: 2,
+		RetryPolicy: &httpcontrol.RetryPolicy{
+			Retriables: []httpcontrol.Retriable{
+				httpcontrol.TemporaryError,
+				httpcontrol.NetworkError,
+				httpcontrol.RetryOnGet,
+			},
+		},
 	}
 	first := false
 	second := false
 	transport.Stats = func(stats *httpcontrol.Stats) {
+		fmt.Println(stats.String())
 		if !first {
 			first = true
 			if stats.Error == nil {

--- a/retry.go
+++ b/retry.go
@@ -21,7 +21,7 @@ var knownFailureSuffixes = []string{
 	"unexpected EOF.",
 }
 
-func shouldRetryDefault(req *http.Request, res *http.Response, err error) bool {
+func ShouldRetryDefault(req *http.Request, res *http.Response, err error) bool {
 	if err == nil {
 		return false
 	}

--- a/retry.go
+++ b/retry.go
@@ -1,8 +1,6 @@
 package httpcontrol
 
 import (
-	"fmt"
-	"log"
 	"math"
 	"net"
 	"net/http"
@@ -10,39 +8,9 @@ import (
 	"time"
 )
 
-type Retriable func(*http.Request, *http.Response, error)
+type Retriable func(*http.Request, *http.Response, error) bool
 
 type Wait func(try uint) time.Duration
-
-type RetryPolicy struct {
-	Retriables []Retriable
-}
-
-// Proceed to the next filter
-func (rp *RetryPolicy) next() Retriable {
-}
-
-func (rp *RetryPolicy) abort() {
-}
-
-func (rp *RetryPolicy) CanRetry(req *http.Request, resp *http.Response, err error) bool {
-	if rp == nil || rp.Retriables == nil {
-		return false
-		if err != nil {
-			return true
-		} else {
-			return false
-		}
-	}
-	log.Println("Retrying")
-	for _, retriable := range rp.Retriables {
-		if !retriable(req, resp, err) {
-			fmt.Println("False!")
-			return false
-		}
-	}
-	return true
-}
 
 var knownFailureSuffixes = []string{
 	"connection refused",
@@ -53,45 +21,34 @@ var knownFailureSuffixes = []string{
 	"unexpected EOF.",
 }
 
-func (rp *RetryPolicy) TemporaryError(req *http.Request, resp *http.Response, err error) {
-	if err != nil {
-		if neterr, ok := err.(net.Error); ok {
-			if neterr.Temporary() {
-				rp.next()
-			}
+func shouldRetryDefault(req *http.Request, res *http.Response, err error) bool {
+	if err == nil {
+		return false
+	}
+	if req.Method != "GET" {
+		return false
+	}
+
+	if neterr, ok := err.(net.Error); ok {
+		if neterr.Temporary() {
+			return true
 		}
 	}
-}
 
-func (rp *RetryPolicy) NetworkError(req *http.Request, resp *http.Response, err error) {
-	if err != nil {
-		s := err.Error()
-		for _, suffix := range knownFailureSuffixes {
-			if strings.HasSuffix(s, suffix) {
-				rp.next()
-			}
+	s := err.Error()
+	for _, suffix := range knownFailureSuffixes {
+		if strings.HasSuffix(s, suffix) {
+			return true
 		}
 	}
+	return false
 }
 
-func (rp *RetryPolicy) RetryOnGet(req *http.Request, res *http.Response, err error) {
-	if req != nil {
-		if req.Method == "GET" {
-			rp.next()
-		}
-	}
-}
-
-func (rp *RetryPolicy) RetryOn4xx(req *http.Request, res *http.Response, err error) {
+func RetryOn4xx(req *http.Request, res *http.Response, err error) bool {
 	if res != nil {
-		if 500 > res.StatusCode && res.StatusCode >= 400 {
-			rp.next()
-		}
+		return 500 > res.StatusCode && res.StatusCode >= 400
 	}
-}
-
-func (rp *RetryPolicy) AlwaysRetry(req *http.Request, resp *http.Response, err error) {
-	rp.next()
+	return false
 }
 
 func ExpBackoff(try uint) {

--- a/retry.go
+++ b/retry.go
@@ -10,7 +10,7 @@ import (
 
 type Retriable func(*http.Request, *http.Response, error) bool
 
-type Wait func(try uint) time.Duration
+type Wait func(try uint)
 
 var knownFailureSuffixes = []string{
 	"connection refused",

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,87 @@
+package httpcontrol
+
+import (
+	"math"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Retriable func(*http.Response, error) bool
+
+type waitTime func(try uint) time.Duration
+
+/*
+type RetryPolicy interface {
+	Retriable(*http.Response, error) bool
+	Wait(uint)
+}
+*/
+
+type RetryPolicy struct {
+	retriables []Retriable
+	/*
+		wait       Wait
+		Retriable  func(*http.Response, error) bool
+	*/
+}
+
+func (rp *RetryPolicy) CanRetry(resp *http.Response, err error) bool {
+	for _, retriable := range rp.retriables {
+		if err != nil {
+			if !retriable(nil, err) {
+				return false
+			}
+		}
+		if resp != nil {
+			if !retriable(resp, err) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var knownFailureSuffixes = []string{
+	"connection refused",
+	"connection reset by peer.",
+	"connection timed out.",
+	"no such host.",
+	"remote error: handshake failure",
+	"unexpected EOF.",
+}
+
+func TemporaryError(req *http.Request, resp *http.Response, err error) bool {
+	if neterr, ok := err.(net.Error); ok {
+		if neterr.Temporary() {
+			return true
+		}
+	}
+	return false
+}
+
+func NetworkError(req *http.Request, resp *http.Response, err error) bool {
+	s := err.Error()
+	for _, suffix := range knownFailureSuffixes {
+		if strings.HasSuffix(s, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func RetryOnGet(req *http.Request, res *http.Response, err error) bool {
+	if req.Method == "GET" {
+		return true
+	}
+	return false
+}
+
+func ExpBackoff(try uint) {
+	time.Sleep(time.Second * time.Duration(math.Exp2(2)))
+}
+
+func LinearBackoff(try uint) {
+	time.Sleep(time.Second * time.Duration(try))
+}

--- a/retry.go
+++ b/retry.go
@@ -10,13 +10,16 @@ import (
 
 type Retriable func(*http.Request, *http.Response, error) bool
 
-type waitTime func(try uint) time.Duration
+type Wait func(try uint) time.Duration
 
 type RetryPolicy struct {
 	retriables []Retriable
 }
 
 func (rp *RetryPolicy) CanRetry(req *http.Request, resp *http.Response, err error) bool {
+	if rp == nil {
+		return true
+	}
 	for _, retriable := range rp.retriables {
 		if !retriable(req, resp, err) {
 			return false
@@ -76,10 +79,17 @@ func RetryOn4xx(req *http.Request, res *http.Response, err error) bool {
 	return 500 > res.StatusCode && res.StatusCode >= 400
 }
 
+func AlwaysRetry(req *http.Request, resp *http.Response, err error) bool {
+	return true
+}
+
 func ExpBackoff(try uint) {
 	time.Sleep(time.Second * time.Duration(math.Exp2(2)))
 }
 
 func LinearBackoff(try uint) {
 	time.Sleep(time.Second * time.Duration(try))
+}
+
+func NoWait(uint) {
 }

--- a/retry.go
+++ b/retry.go
@@ -69,6 +69,13 @@ func RetryOnGet(req *http.Request, res *http.Response, err error) bool {
 	return false
 }
 
+func RetryOn4xx(req *http.Request, res *http.Response, err error) bool {
+	if res == nil {
+		return true
+	}
+	return 500 > res.StatusCode && res.StatusCode >= 400
+}
+
 func ExpBackoff(try uint) {
 	time.Sleep(time.Second * time.Duration(math.Exp2(2)))
 }


### PR DESCRIPTION
I want to use this for aws, where the heuristics in the built-in shouldRetry function don't apply. AWS APIs have application-level semantics that describe their retriability.

To make this useful for more cases, I broke out the method that checks if the request can be retried, and added an optional wait function.
### TODO
- [ ] code review
- [ ] tests (I've been using this test script https://gist.github.com/mwhooker/7276016)
- [ ] documentation
