### PR TITLE
Remove trailing period from "no such host"

### DIFF
--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -140,7 +140,7 @@ var knownFailureSuffixes = []string{
 	"connection refused",
 	"connection reset by peer.",
 	"connection timed out.",
-	"no such host.",
+	"no such host",
 	"remote error: handshake failure",
 	"unexpected EOF.",
 }


### PR DESCRIPTION
Fix retry logic to actually retry DNS resolution issues by removing trailing `.` to match [`net.noSuchHost`](https://golang.org/src/pkg/net/dnsclient.go).
