### PR TITLE
Fix known failure suffixes

### DIFF
--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/pqueue"
+	"syscall"
 )
 
 // Stats for a RoundTrip.
@@ -137,13 +138,13 @@ type Transport struct {
 }
 
 var knownFailureSuffixes = []string{
-	"connection refused",
-	"connection reset by peer.",
-	"connection timed out.",
+	syscall.ECONNREFUSED.Error(),
+	syscall.ECONNRESET.Error(),
+	syscall.ETIMEDOUT.Error(),
 	"no such host",
 	"remote error: handshake failure",
-	"unexpected EOF.",
-	"EOF",
+	io.ErrUnexpectedEOF.Error(),
+	io.EOF.Error(),
 }
 
 func shouldRetryError(err error) bool {

--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -143,6 +143,7 @@ var knownFailureSuffixes = []string{
 	"no such host",
 	"remote error: handshake failure",
 	"unexpected EOF.",
+	"EOF",
 }
 
 func shouldRetryError(err error) bool {


### PR DESCRIPTION
This is similar to my fix in https://github.com/facebookgo/httpcontrol/pull/2 for `no such host`, but I since realized that the issue with the trailing periods affects other errors from being retried as well. This does the following:
- Removes trailing periods from other errors. As far as I can tell, none of these will have trailing periods.
- Replaces strings with constants from where the errors originate where possible. The others are private fields or generated within private functions in other packages.
- Adds a retry for `io.EOF` with a test show how this can happen. (This has happened to me a few times in production so far.)
