### PR TITLE
Expose Dialer into Transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
-  - 1.2
+  - 1.3
 install:
   - go get -t ./...


### PR DESCRIPTION
@daaku 

Hey, nice package ! (using it in production)

Want to expose/make public Dailer struct into Transport since more or less it is already custom. Reason & benefits is additional configuration of Dialer var 'KeepAlive':

``` go
// KeepAlive specifies the keep-alive period for an active
// network connection.
// If zero, keep-alives are not enabled. Network protocols
// that do not support keep-alives ignore this field.
KeepAlive time.Duration
```
