### PR TITLE
Retry after timeouts

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/facebookgo/httpcontrol"
+	"github.com/dvdplm/httpcontrol"
 )
 
 func Example() {

--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -122,6 +122,13 @@ type Transport struct {
 	// as the entire body.
 	RequestTimeout time.Duration
 
+	// RetryAfterTimeout, if true, will enable retries for a number of failures
+	// that are probably safe to retry for most cases but, depending on the
+	// context, might not be safe. Retried errors: net.Errors where Timeout()
+	// returns `true` or timeouts that bubble up as url.Error but were originally
+	// net.Error, OpErrors where the request was cancelled (either by this lib or
+	// by the calling code, or finally errors from requests that were cancelled
+	// before the remote side was contacted.
 	RetryAfterTimeout bool
 
 	// MaxTries, if non-zero, specifies the number of times we will retry on

--- a/httpcontrol.go
+++ b/httpcontrol.go
@@ -159,23 +159,27 @@ func (t *Transport) shouldRetryError(err error) bool {
 
 	if t.RetryAfterTimeout {
 		if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
+			fmt.Printf("TIMEOUT neterr: %v\n", err)
 			return true
 		}
 
 		// http://stackoverflow.com/questions/23494950/specifically-check-for-timeout-error
 		if urlerr, ok := err.(*url.Error); ok {
 			if neturlerr, ok := urlerr.Err.(net.Error); ok && neturlerr.Timeout() {
+				fmt.Printf("TIMEOUT net error inside url error: %v\n", err)
 				return true
 			}
 		}
 		if operr, ok := err.(*net.OpError); ok {
 			if strings.Contains(operr.Error(), "use of closed network connection") {
+				fmt.Printf("TIMEOUT op error: %v\n", err)
 				return true
 			}
 		}
 
 		// The request timed out before we could connect
 		if strings.Contains(err.Error(), "request canceled while waiting for connection") {
+			fmt.Printf("TIMEOUT dial timeout: %v\n", err)
 			return true
 		}
 	}
@@ -287,7 +291,6 @@ func (t *Transport) tries(req *http.Request, try uint) (*http.Response, error) {
 		}
 
 		if try < t.MaxTries && req.Method == "GET" && t.shouldRetryError(err) {
-			fmt.Printf("[tries] RETRYING. ATTEMPT %d/%d\n", try, t.MaxTries)
 			if t.Stats != nil {
 				stats.Retry.Pending = true
 				t.Stats(stats)

--- a/httpcontrol_test.go
+++ b/httpcontrol_test.go
@@ -3,6 +3,7 @@ package httpcontrol_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -12,9 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dvdplm/httpcontrol"
 	"github.com/facebookgo/freeport"
-	"github.com/facebookgo/httpcontrol"
-	"io"
 )
 
 var theAnswer = []byte("42")
@@ -66,153 +66,214 @@ func call(f func() error, t *testing.T) {
 	}
 }
 
-func TestOkWithDefaults(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(sleepHandler(time.Millisecond))
-	defer server.Close()
-	transport := &httpcontrol.Transport{}
-	hit := false
-	transport.Stats = func(stats *httpcontrol.Stats) {
-		hit = true
-		if stats.Error != nil {
-			t.Fatal(stats.Error)
-		}
-		if stats.Request == nil {
-			t.Fatal("got nil request in stats")
-		}
-		if stats.Response == nil {
-			t.Fatal("got nil response in stats")
-		}
-		if stats.Retry.Count != 0 {
-			t.Fatal("was expecting retry count of 0")
-		}
-		if stats.Retry.Pending {
-			t.Fatal("was expecting no retry pending")
-		}
-	}
-	defer call(transport.Close, t)
-	client := &http.Client{Transport: transport}
-	res, err := client.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertResponse(res, t)
-	if !hit {
-		t.Fatal("no hit")
-	}
-}
+// func TestOkWithDefaults(t *testing.T) {
+// 	t.Parallel()
+// 	server := httptest.NewServer(sleepHandler(time.Millisecond))
+// 	defer server.Close()
+// 	transport := &httpcontrol.Transport{}
+// 	hit := false
+// 	transport.Stats = func(stats *httpcontrol.Stats) {
+// 		hit = true
+// 		if stats.Error != nil {
+// 			t.Fatal(stats.Error)
+// 		}
+// 		if stats.Request == nil {
+// 			t.Fatal("got nil request in stats")
+// 		}
+// 		if stats.Response == nil {
+// 			t.Fatal("got nil response in stats")
+// 		}
+// 		if stats.Retry.Count != 0 {
+// 			t.Fatal("was expecting retry count of 0")
+// 		}
+// 		if stats.Retry.Pending {
+// 			t.Fatal("was expecting no retry pending")
+// 		}
+// 	}
+// 	defer call(transport.Close, t)
+// 	client := &http.Client{Transport: transport}
+// 	res, err := client.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	assertResponse(res, t)
+// 	if !hit {
+// 		t.Fatal("no hit")
+// 	}
+// }
 
-func TestHttpError(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(errorHandler(time.Millisecond))
-	defer server.Close()
-	transport := &httpcontrol.Transport{}
-	transport.Stats = func(stats *httpcontrol.Stats) {
-		if stats.Error != nil {
-			t.Fatal(stats.Error)
-		}
-	}
-	defer call(transport.Close, t)
-	client := &http.Client{Transport: transport}
-	res, err := client.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertResponse(res, t)
-	if res.StatusCode != 500 {
-		t.Fatalf("was expecting 500 got %d", res.StatusCode)
-	}
-}
+// func TestHttpError(t *testing.T) {
+// 	t.Parallel()
+// 	server := httptest.NewServer(errorHandler(time.Millisecond))
+// 	defer server.Close()
+// 	transport := &httpcontrol.Transport{}
+// 	transport.Stats = func(stats *httpcontrol.Stats) {
+// 		if stats.Error != nil {
+// 			t.Fatal(stats.Error)
+// 		}
+// 	}
+// 	defer call(transport.Close, t)
+// 	client := &http.Client{Transport: transport}
+// 	res, err := client.Get(server.URL)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	assertResponse(res, t)
+// 	if res.StatusCode != 500 {
+// 		t.Fatalf("was expecting 500 got %d", res.StatusCode)
+// 	}
+// }
 
-func TestDialNoServer(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(sleepHandler(time.Millisecond))
-	server.Close()
-	transport := &httpcontrol.Transport{}
-	transport.Stats = func(stats *httpcontrol.Stats) {
-		if stats.Error == nil {
-			t.Fatal("was expecting error")
-		}
-	}
-	defer call(transport.Close, t)
-	client := &http.Client{Transport: transport}
-	res, err := client.Get(server.URL)
-	if err == nil {
-		t.Fatal("was expecting an error")
-	}
-	if res != nil {
-		t.Fatal("was expecting nil response")
-	}
-	if !strings.Contains(err.Error(), "dial") {
-		t.Fatal("was expecting dial related error")
-	}
-}
+// func TestDialNoServer(t *testing.T) {
+// 	t.Parallel()
+// 	server := httptest.NewServer(sleepHandler(time.Millisecond))
+// 	server.Close()
+// 	transport := &httpcontrol.Transport{}
+// 	transport.Stats = func(stats *httpcontrol.Stats) {
+// 		if stats.Error == nil {
+// 			t.Fatal("was expecting error")
+// 		}
+// 	}
+// 	defer call(transport.Close, t)
+// 	client := &http.Client{Transport: transport}
+// 	res, err := client.Get(server.URL)
+// 	if err == nil {
+// 		t.Fatal("was expecting an error")
+// 	}
+// 	if res != nil {
+// 		t.Fatal("was expecting nil response")
+// 	}
+// 	if !strings.Contains(err.Error(), "dial") {
+// 		t.Fatal("was expecting dial related error")
+// 	}
+// }
 
-func TestResponseHeaderTimeout(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(sleepHandler(5 * time.Second))
-	transport := &httpcontrol.Transport{
-		ResponseHeaderTimeout: 50 * time.Millisecond,
-	}
-	transport.Stats = func(stats *httpcontrol.Stats) {
-		if stats.Error == nil {
-			t.Fatal("was expecting error")
-		}
-	}
-	defer call(transport.Close, t)
-	client := &http.Client{Transport: transport}
-	res, err := client.Get(server.URL)
-	if err == nil {
-		t.Fatal("was expecting an error")
-	}
-	if res != nil {
-		t.Fatal("was expecting nil response")
-	}
+// func TestResponseHeaderTimeout(t *testing.T) {
+// 	t.Parallel()
+// 	server := httptest.NewServer(sleepHandler(5 * time.Second))
+// 	transport := &httpcontrol.Transport{
+// 		ResponseHeaderTimeout: 50 * time.Millisecond,
+// 	}
+// 	transport.Stats = func(stats *httpcontrol.Stats) {
+// 		if stats.Error == nil {
+// 			t.Fatal("was expecting error")
+// 		}
+// 	}
+// 	defer call(transport.Close, t)
+// 	client := &http.Client{Transport: transport}
+// 	res, err := client.Get(server.URL)
+// 	if err == nil {
+// 		t.Fatal("was expecting an error")
+// 	}
+// 	if res != nil {
+// 		t.Fatal("was expecting nil response")
+// 	}
 
-	const expected = "timeout awaiting response headers"
-	if !strings.Contains(err.Error(), expected) {
-		t.Fatalf(`expected "%s" got "%s"`, expected, err)
-	}
-}
+// 	const expected = "timeout awaiting response headers"
+// 	if !strings.Contains(err.Error(), expected) {
+// 		t.Fatalf(`expected "%s" got "%s"`, expected, err)
+// 	}
+// }
 
-func TestResponseTimeout(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(sleepHandler(5 * time.Second))
-	transport := &httpcontrol.Transport{
-		RequestTimeout: 50 * time.Millisecond,
-	}
-	transport.Stats = func(stats *httpcontrol.Stats) {
-		if stats.Error == nil {
-			t.Fatal("was expecting error")
-		}
-	}
-	defer call(transport.Close, t)
-	client := &http.Client{Transport: transport}
-	res, err := client.Get(server.URL)
-	if err == nil {
-		t.Fatal("was expecting an error")
-	}
-	if res != nil {
-		t.Fatal("was expecting nil response")
-	}
-	if !strings.Contains(err.Error(), "use of closed network connection") {
-		t.Fatalf("was expecting closed network connection related error, got %s", err)
-	}
-}
+// func TestResponseTimeout(t *testing.T) {
+// 	t.Parallel()
+// 	server := httptest.NewServer(sleepHandler(5 * time.Second))
+// 	transport := &httpcontrol.Transport{
+// 		RequestTimeout: 50 * time.Millisecond,
+// 	}
+// 	transport.Stats = func(stats *httpcontrol.Stats) {
+// 		if stats.Error == nil {
+// 			t.Fatal("was expecting error")
+// 		}
+// 	}
+// 	defer call(transport.Close, t)
+// 	client := &http.Client{Transport: transport}
+// 	res, err := client.Get(server.URL)
+// 	if err == nil {
+// 		t.Fatal("was expecting an error")
+// 	}
+// 	if res != nil {
+// 		t.Fatal("was expecting nil response")
+// 	}
+// 	if !strings.Contains(err.Error(), "use of closed network connection") {
+// 		t.Fatalf("was expecting closed network connection related error, got %s", err)
+// 	}
+// }
 
-func TestSafeRetry(t *testing.T) {
+// func TestSafeRetry(t *testing.T) {
+// 	t.Parallel()
+// 	port, err := freeport.Get()
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	addr := fmt.Sprintf("127.0.0.1:%d", port)
+// 	server := httptest.NewUnstartedServer(sleepHandler(time.Millisecond))
+// 	transport := &httpcontrol.Transport{
+// 		MaxTries: 2,
+// 	}
+// 	first := false
+// 	second := false
+// 	transport.Stats = func(stats *httpcontrol.Stats) {
+// 		if !first {
+// 			first = true
+// 			if stats.Error == nil {
+// 				t.Fatal("was expecting error")
+// 			}
+// 			if !stats.Retry.Pending {
+// 				t.Fatal("was expecting pending retry", stats.Error)
+// 			}
+// 			server.Listener, err = net.Listen("tcp", addr)
+// 			if err != nil {
+// 				t.Fatal(err)
+// 			}
+// 			server.Start()
+// 			return
+// 		}
+
+// 		if !second {
+// 			second = true
+// 			if stats.Error != nil {
+// 				t.Fatal(stats.Error, server.URL)
+// 			}
+// 			return
+// 		}
+// 	}
+// 	defer call(transport.Close, t)
+// 	client := &http.Client{Transport: transport}
+// 	res, err := client.Get(fmt.Sprintf("http://%s/", addr))
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	assertResponse(res, t)
+// 	if !first {
+// 		t.Fatal("did not see first request")
+// 	}
+// 	if !second {
+// 		t.Fatal("did not see second request")
+// 	}
+// }
+
+func TestSafeRetryAfterTimeout(t *testing.T) {
 	t.Parallel()
 	port, err := freeport.Get()
 	if err != nil {
 		t.Fatal(err)
 	}
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	server := httptest.NewUnstartedServer(sleepHandler(time.Millisecond))
+	// server := httptest.NewServer(sleepHandler(5 * time.Second))
+	// transport := &httpcontrol.Transport{
+	// 	RequestTimeout: 50 * time.Millisecond,
+	// }
+
+	server := httptest.NewUnstartedServer(sleepHandler(5 * time.Second))
 	transport := &httpcontrol.Transport{
-		MaxTries: 2,
+		MaxTries:          3,
+		RequestTimeout:    5 * time.Millisecond,
+		RetryAfterTimeout: true,
 	}
 	first := false
 	second := false
+	third := false
 	transport.Stats = func(stats *httpcontrol.Stats) {
 		if !first {
 			first = true
@@ -232,24 +293,43 @@ func TestSafeRetry(t *testing.T) {
 
 		if !second {
 			second = true
-			if stats.Error != nil {
-				t.Fatal(stats.Error, server.URL)
+			if stats.Error == nil {
+				t.Fatal("was expecting error")
+			}
+			if !stats.Retry.Pending {
+				t.Fatal("was expecting pending retry", stats.Error)
 			}
 			return
+		}
+
+		if !third {
+			third = true
+			if stats.Error == nil {
+				t.Fatal("was expecting error")
+			}
+			if !stats.Retry.Pending {
+				t.Fatal("was expecting pending retry", stats.Error)
+			}
 		}
 	}
 	defer call(transport.Close, t)
 	client := &http.Client{Transport: transport}
-	res, err := client.Get(fmt.Sprintf("http://%s/", addr))
-	if err != nil {
+	_, err = client.Get(fmt.Sprintf("http://%s/", addr))
+
+	// Expect this to fail
+	if err == nil {
 		t.Fatal(err)
 	}
-	assertResponse(res, t)
+
 	if !first {
 		t.Fatal("did not see first request")
 	}
 	if !second {
 		t.Fatal("did not see second request")
+	}
+
+	if !third {
+		t.Fatal("did not see third request")
 	}
 }
 

--- a/httpcontrol_test.go
+++ b/httpcontrol_test.go
@@ -66,192 +66,192 @@ func call(f func() error, t *testing.T) {
 	}
 }
 
-// func TestOkWithDefaults(t *testing.T) {
-// 	t.Parallel()
-// 	server := httptest.NewServer(sleepHandler(time.Millisecond))
-// 	defer server.Close()
-// 	transport := &httpcontrol.Transport{}
-// 	hit := false
-// 	transport.Stats = func(stats *httpcontrol.Stats) {
-// 		hit = true
-// 		if stats.Error != nil {
-// 			t.Fatal(stats.Error)
-// 		}
-// 		if stats.Request == nil {
-// 			t.Fatal("got nil request in stats")
-// 		}
-// 		if stats.Response == nil {
-// 			t.Fatal("got nil response in stats")
-// 		}
-// 		if stats.Retry.Count != 0 {
-// 			t.Fatal("was expecting retry count of 0")
-// 		}
-// 		if stats.Retry.Pending {
-// 			t.Fatal("was expecting no retry pending")
-// 		}
-// 	}
-// 	defer call(transport.Close, t)
-// 	client := &http.Client{Transport: transport}
-// 	res, err := client.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	assertResponse(res, t)
-// 	if !hit {
-// 		t.Fatal("no hit")
-// 	}
-// }
+func TestOkWithDefaults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(sleepHandler(time.Millisecond))
+	defer server.Close()
+	transport := &httpcontrol.Transport{}
+	hit := false
+	transport.Stats = func(stats *httpcontrol.Stats) {
+		hit = true
+		if stats.Error != nil {
+			t.Fatal(stats.Error)
+		}
+		if stats.Request == nil {
+			t.Fatal("got nil request in stats")
+		}
+		if stats.Response == nil {
+			t.Fatal("got nil response in stats")
+		}
+		if stats.Retry.Count != 0 {
+			t.Fatal("was expecting retry count of 0")
+		}
+		if stats.Retry.Pending {
+			t.Fatal("was expecting no retry pending")
+		}
+	}
+	defer call(transport.Close, t)
+	client := &http.Client{Transport: transport}
+	res, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertResponse(res, t)
+	if !hit {
+		t.Fatal("no hit")
+	}
+}
 
-// func TestHttpError(t *testing.T) {
-// 	t.Parallel()
-// 	server := httptest.NewServer(errorHandler(time.Millisecond))
-// 	defer server.Close()
-// 	transport := &httpcontrol.Transport{}
-// 	transport.Stats = func(stats *httpcontrol.Stats) {
-// 		if stats.Error != nil {
-// 			t.Fatal(stats.Error)
-// 		}
-// 	}
-// 	defer call(transport.Close, t)
-// 	client := &http.Client{Transport: transport}
-// 	res, err := client.Get(server.URL)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	assertResponse(res, t)
-// 	if res.StatusCode != 500 {
-// 		t.Fatalf("was expecting 500 got %d", res.StatusCode)
-// 	}
-// }
+func TestHttpError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(errorHandler(time.Millisecond))
+	defer server.Close()
+	transport := &httpcontrol.Transport{}
+	transport.Stats = func(stats *httpcontrol.Stats) {
+		if stats.Error != nil {
+			t.Fatal(stats.Error)
+		}
+	}
+	defer call(transport.Close, t)
+	client := &http.Client{Transport: transport}
+	res, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertResponse(res, t)
+	if res.StatusCode != 500 {
+		t.Fatalf("was expecting 500 got %d", res.StatusCode)
+	}
+}
 
-// func TestDialNoServer(t *testing.T) {
-// 	t.Parallel()
-// 	server := httptest.NewServer(sleepHandler(time.Millisecond))
-// 	server.Close()
-// 	transport := &httpcontrol.Transport{}
-// 	transport.Stats = func(stats *httpcontrol.Stats) {
-// 		if stats.Error == nil {
-// 			t.Fatal("was expecting error")
-// 		}
-// 	}
-// 	defer call(transport.Close, t)
-// 	client := &http.Client{Transport: transport}
-// 	res, err := client.Get(server.URL)
-// 	if err == nil {
-// 		t.Fatal("was expecting an error")
-// 	}
-// 	if res != nil {
-// 		t.Fatal("was expecting nil response")
-// 	}
-// 	if !strings.Contains(err.Error(), "dial") {
-// 		t.Fatal("was expecting dial related error")
-// 	}
-// }
+func TestDialNoServer(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(sleepHandler(time.Millisecond))
+	server.Close()
+	transport := &httpcontrol.Transport{}
+	transport.Stats = func(stats *httpcontrol.Stats) {
+		if stats.Error == nil {
+			t.Fatal("was expecting error")
+		}
+	}
+	defer call(transport.Close, t)
+	client := &http.Client{Transport: transport}
+	res, err := client.Get(server.URL)
+	if err == nil {
+		t.Fatal("was expecting an error")
+	}
+	if res != nil {
+		t.Fatal("was expecting nil response")
+	}
+	if !strings.Contains(err.Error(), "dial") {
+		t.Fatal("was expecting dial related error")
+	}
+}
 
-// func TestResponseHeaderTimeout(t *testing.T) {
-// 	t.Parallel()
-// 	server := httptest.NewServer(sleepHandler(5 * time.Second))
-// 	transport := &httpcontrol.Transport{
-// 		ResponseHeaderTimeout: 50 * time.Millisecond,
-// 	}
-// 	transport.Stats = func(stats *httpcontrol.Stats) {
-// 		if stats.Error == nil {
-// 			t.Fatal("was expecting error")
-// 		}
-// 	}
-// 	defer call(transport.Close, t)
-// 	client := &http.Client{Transport: transport}
-// 	res, err := client.Get(server.URL)
-// 	if err == nil {
-// 		t.Fatal("was expecting an error")
-// 	}
-// 	if res != nil {
-// 		t.Fatal("was expecting nil response")
-// 	}
+func TestResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(sleepHandler(5 * time.Second))
+	transport := &httpcontrol.Transport{
+		ResponseHeaderTimeout: 50 * time.Millisecond,
+	}
+	transport.Stats = func(stats *httpcontrol.Stats) {
+		if stats.Error == nil {
+			t.Fatal("was expecting error")
+		}
+	}
+	defer call(transport.Close, t)
+	client := &http.Client{Transport: transport}
+	res, err := client.Get(server.URL)
+	if err == nil {
+		t.Fatal("was expecting an error")
+	}
+	if res != nil {
+		t.Fatal("was expecting nil response")
+	}
 
-// 	const expected = "timeout awaiting response headers"
-// 	if !strings.Contains(err.Error(), expected) {
-// 		t.Fatalf(`expected "%s" got "%s"`, expected, err)
-// 	}
-// }
+	const expected = "timeout awaiting response headers"
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf(`expected "%s" got "%s"`, expected, err)
+	}
+}
 
-// func TestResponseTimeout(t *testing.T) {
-// 	t.Parallel()
-// 	server := httptest.NewServer(sleepHandler(5 * time.Second))
-// 	transport := &httpcontrol.Transport{
-// 		RequestTimeout: 50 * time.Millisecond,
-// 	}
-// 	transport.Stats = func(stats *httpcontrol.Stats) {
-// 		if stats.Error == nil {
-// 			t.Fatal("was expecting error")
-// 		}
-// 	}
-// 	defer call(transport.Close, t)
-// 	client := &http.Client{Transport: transport}
-// 	res, err := client.Get(server.URL)
-// 	if err == nil {
-// 		t.Fatal("was expecting an error")
-// 	}
-// 	if res != nil {
-// 		t.Fatal("was expecting nil response")
-// 	}
-// 	if !strings.Contains(err.Error(), "use of closed network connection") {
-// 		t.Fatalf("was expecting closed network connection related error, got %s", err)
-// 	}
-// }
+func TestResponseTimeout(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(sleepHandler(5 * time.Second))
+	transport := &httpcontrol.Transport{
+		RequestTimeout: 50 * time.Millisecond,
+	}
+	transport.Stats = func(stats *httpcontrol.Stats) {
+		if stats.Error == nil {
+			t.Fatal("was expecting error")
+		}
+	}
+	defer call(transport.Close, t)
+	client := &http.Client{Transport: transport}
+	res, err := client.Get(server.URL)
+	if err == nil {
+		t.Fatal("was expecting an error")
+	}
+	if res != nil {
+		t.Fatal("was expecting nil response")
+	}
+	if !strings.Contains(err.Error(), "use of closed network connection") {
+		t.Fatalf("was expecting closed network connection related error, got %s", err)
+	}
+}
 
-// func TestSafeRetry(t *testing.T) {
-// 	t.Parallel()
-// 	port, err := freeport.Get()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-// 	server := httptest.NewUnstartedServer(sleepHandler(time.Millisecond))
-// 	transport := &httpcontrol.Transport{
-// 		MaxTries: 2,
-// 	}
-// 	first := false
-// 	second := false
-// 	transport.Stats = func(stats *httpcontrol.Stats) {
-// 		if !first {
-// 			first = true
-// 			if stats.Error == nil {
-// 				t.Fatal("was expecting error")
-// 			}
-// 			if !stats.Retry.Pending {
-// 				t.Fatal("was expecting pending retry", stats.Error)
-// 			}
-// 			server.Listener, err = net.Listen("tcp", addr)
-// 			if err != nil {
-// 				t.Fatal(err)
-// 			}
-// 			server.Start()
-// 			return
-// 		}
+func TestSafeRetry(t *testing.T) {
+	t.Parallel()
+	port, err := freeport.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	server := httptest.NewUnstartedServer(sleepHandler(time.Millisecond))
+	transport := &httpcontrol.Transport{
+		MaxTries: 2,
+	}
+	first := false
+	second := false
+	transport.Stats = func(stats *httpcontrol.Stats) {
+		if !first {
+			first = true
+			if stats.Error == nil {
+				t.Fatal("was expecting error")
+			}
+			if !stats.Retry.Pending {
+				t.Fatal("was expecting pending retry", stats.Error)
+			}
+			server.Listener, err = net.Listen("tcp", addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			server.Start()
+			return
+		}
 
-// 		if !second {
-// 			second = true
-// 			if stats.Error != nil {
-// 				t.Fatal(stats.Error, server.URL)
-// 			}
-// 			return
-// 		}
-// 	}
-// 	defer call(transport.Close, t)
-// 	client := &http.Client{Transport: transport}
-// 	res, err := client.Get(fmt.Sprintf("http://%s/", addr))
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	assertResponse(res, t)
-// 	if !first {
-// 		t.Fatal("did not see first request")
-// 	}
-// 	if !second {
-// 		t.Fatal("did not see second request")
-// 	}
-// }
+		if !second {
+			second = true
+			if stats.Error != nil {
+				t.Fatal(stats.Error, server.URL)
+			}
+			return
+		}
+	}
+	defer call(transport.Close, t)
+	client := &http.Client{Transport: transport}
+	res, err := client.Get(fmt.Sprintf("http://%s/", addr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertResponse(res, t)
+	if !first {
+		t.Fatal("did not see first request")
+	}
+	if !second {
+		t.Fatal("did not see second request")
+	}
+}
 
 func TestSafeRetryAfterTimeout(t *testing.T) {
 	t.Parallel()
@@ -260,11 +260,6 @@ func TestSafeRetryAfterTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	// server := httptest.NewServer(sleepHandler(5 * time.Second))
-	// transport := &httpcontrol.Transport{
-	// 	RequestTimeout: 50 * time.Millisecond,
-	// }
-
 	server := httptest.NewUnstartedServer(sleepHandler(5 * time.Second))
 	transport := &httpcontrol.Transport{
 		MaxTries:          3,


### PR DESCRIPTION
Adds a config option, `RetryAfterTimeout`, that when true enables retries for a number of network related failures that _might_ be safe to retry, depending on the calling context.

From the doc comment:

```
    RetryAfterTimeout, if true, will enable retries for a number of failures
    that are probably safe to retry for most cases but, depending on the
    context, might not be safe. Retried errors: net.Errors where Timeout()
    returns `true` or timeouts that bubble up as url.Error but were originally
    net.Error, OpErrors where the request was cancelled (either by this lib or
    by the calling code, or finally errors from requests that were cancelled
    before the remote side was contacted.
```
